### PR TITLE
Move conversations to IndexedDB

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -8,3 +8,11 @@ Vivica previously persisted all persona memory under a single `vivica-memory` ke
 
 On launch the app will clean up the old `vivica-memory` key if it still exists.
 All components read and write only from the new scoped keys.
+
+# Conversation storage migration
+
+Chat conversations were previously saved in `localStorage` under the
+`vivica-conversations` key. To improve durability and allow larger histories,
+conversations are now persisted in the IndexedDB `conversations` store. On
+startup any existing `vivica-conversations` data will be imported into
+IndexedDB and then removed from `localStorage`.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 ## Features
 
-- **True Local-First Design:**  
-  All chat, memory, API keys, and settings are stored _locally_. No cloud sync, no account needed, and your data is yours.
+- **True Local-First Design:**
+  All chat, memory, API keys, and settings are stored _locally_. No cloud sync, no account needed, and your data is yours. Conversations are persisted in **IndexedDB** for extra durability.
 
 - **Personalities & Personas:**  
   - **Vivica** is the always-on, never-deletable default persona:  


### PR DESCRIPTION
## Summary
- store conversations in IndexedDB instead of localStorage
- add DB helpers for conversation storage
- migrate any legacy `vivica-conversations` data on startup
- document the conversation storage migration
- note IndexedDB persistence in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884e3d311ec832a9c569afe98451e9a