### PR TITLE
Enhance code message animation

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -86,6 +86,8 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
     const [welcomeError, setWelcomeError] = useState(false);
     const [animateWelcome, setAnimateWelcome] = useState(false);
     const lastWelcomeRef = useRef('');
+    const lastMessage = conversation?.messages?.[conversation.messages.length - 1];
+    const showThinking = isTyping && !(lastMessage?.isCodeResponse);
 
     const fetchWelcome = useCallback(async () => {
       if (!conversation || conversation.messages.length) return;
@@ -228,7 +230,7 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                 key={message.id}
                 className={`flex flex-col ${
                   message.role === 'user' ? 'items-end' : 'items-start'
-                } mb-2 slide-up group`}
+                } mb-2 ${message.isCodeResponse ? '' : 'slide-up'} group`}
               >
                 <div
                   className={`flex items-center gap-2 mb-0.5 ${
@@ -255,6 +257,8 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                   
                   <div
                     className={`message-bubble ${message.role} ${
+                      message.isCodeResponse ? 'code-bubble' : ''
+                    } ${
                       message.failed ? 'border-accent/50 bg-accent/10' : ''
                     } px-3 py-2 rounded-2xl max-w-[95vw] sm:max-w-2xl break-words ${
                       message.role === 'user'
@@ -380,7 +384,7 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
 
 
             <div ref={messagesEndRef} />
-            {isTyping && (
+            {showThinking && (
               <div className="px-6 pt-2">
                 <ThinkingIndicator />
               </div>

--- a/src/components/CodeBlockLoader.tsx
+++ b/src/components/CodeBlockLoader.tsx
@@ -1,12 +1,9 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { Loader2 } from "lucide-react";
 
 export function CodeBlockLoader() {
   return (
-    <div className="code-block-container space-y-2" role="status" aria-busy="true">
-      <Skeleton className="code-block" />
-      <div className="h-1 w-full bg-muted overflow-hidden rounded relative">
-        <div className="absolute inset-0 w-1/3 bg-accent animate-indeterminate" />
-      </div>
+    <div className="flex items-center justify-center py-8" role="status" aria-busy="true">
+      <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
       <span className="sr-only">AI is generating code...</span>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -654,6 +654,8 @@
     "Liberation Mono", "Courier New", monospace;
   border: 1px solid hsl(var(--border-custom));
   box-shadow: 0 1px 4px hsl(var(--shadow));
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 /* Inline code styling */
@@ -699,9 +701,9 @@
   color: #f6f8fa;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   line-height: 1.4;
-  padding: 0.5rem;
+  padding: 0.25rem 0.375rem;
   border-radius: 0.375rem;
   overflow-x: hidden;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- swap code generation loader for simple spinner
- apply distinct style for code bubbles and only animate text bubbles
- shrink code block font and padding
- hide progress bar when generating code

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68855d18de0c832aa53f2c9299d660f4