### PR TITLE
Improve chat bubbles styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@eslint/js": "^9.9.0",
+        "@eslint/js": "^9.32.0",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^9.32.0",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",

--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -260,10 +260,12 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
                       message.isCodeResponse ? 'code-bubble' : ''
                     } ${
                       message.failed ? 'border-accent/50 bg-accent/10' : ''
-                    } px-3 py-2 rounded-2xl max-w-[95vw] sm:max-w-2xl break-words ${
+                    } px-3 py-2 rounded-3xl max-w-[95vw] sm:max-w-2xl break-words ${
                       message.role === 'user'
                         ? 'rounded-br-none ml-6 mr-2000'
                         : 'rounded-bl-none mr-6 ml-6'
+                    } ${
+                      index === conversation?.messages.length - 1 ? 'glow-once' : ''
                     }`}
                   >
                     <div className="prose dark:prose-invert break-words max-w-none text-sm leading-snug">

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -35,6 +35,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', `${color}-${variant}`);
+    document.documentElement.classList.toggle('dark', variant === 'dark');
     DebouncedStorage.set(STORAGE_KEYS.THEME, { color, variant }, 300);
   }, [color, variant]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -575,6 +575,10 @@
   animation: pulseGlow 2s infinite;
 }
 
+.glow-once {
+  animation: pulseGlow 1s ease-out;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }
@@ -602,31 +606,43 @@
 
 
 /* Message bubble styles */
+
+/* Modern chat bubble styling */
 .message-bubble {
   max-width: 100%;
   padding: 10px 14px;
-  border-radius: 18px;
+  border-radius: 1.5rem;
   margin: 4px 0;
   position: relative;
   word-wrap: break-word;
+  border: 1px solid hsl(var(--border-light) / 0.5);
+  box-shadow: 0 1px 3px hsl(var(--shadow));
 }
 
 .message-bubble.user {
   position: left;
   max-width: 90%;
-  background: var(--user-bubble-bg);
+  background: hsl(var(--user-bubble-bg) / 0.95);
   color: var(--user-bubble-text);
-  border-bottom-right-radius: 6px;
-  border: var(--user-bubble-border);
+  border-bottom-right-radius: 0.75rem;
 }
 
 .message-bubble.assistant {
   position: right;
   max-width: 95%;
-  background: var(--assistant-bubble-bg);
+  background: hsl(var(--assistant-bubble-bg) / 0.95);
   color: var(--assistant-bubble-text);
-  border-bottom-left-radius: 6px;
-  border: var(--assistant-bubble-border);
+  border-bottom-left-radius: 0.75rem;
+}
+
+.dark .message-bubble.user {
+  background: hsl(var(--user-bubble-bg) / 0.25);
+  box-shadow: 0 1px 3px hsl(var(--shadow)), 0 0 6px hsla(140, 100%, 50%, 0.3);
+}
+
+.dark .message-bubble.assistant {
+  background: hsl(var(--assistant-bubble-bg) / 0.25);
+  box-shadow: 0 1px 3px hsl(var(--shadow)), 0 0 6px hsla(190, 100%, 70%, 0.3);
 }
 
 .message-bubble .prose {
@@ -649,13 +665,18 @@
 
 /* Distinct styling for messages containing code */
 .code-bubble {
-  background: hsl(var(--bg-tertiary));
+  background: hsl(var(--bg-tertiary) / 0.8);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
-  border: 1px solid hsl(var(--border-custom));
-  box-shadow: 0 1px 4px hsl(var(--shadow));
+  border: 1px solid hsl(var(--border-light) / 0.5);
+  box-shadow: 0 1px 3px hsl(var(--shadow));
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+  border-radius: 1.25rem;
+}
+
+.dark .code-bubble {
+  background: hsl(var(--bg-tertiary) / 0.4);
 }
 
 /* Inline code styling */
@@ -697,17 +718,24 @@
 }
 
 .code-block {
-  background: #24292f;
-  color: #f6f8fa;
+  background: hsl(var(--bg-tertiary) / 0.9);
+  color: hsl(var(--foreground));
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.6875rem;
   line-height: 1.4;
-  padding: 0.25rem 0.375rem;
-  border-radius: 0.375rem;
-  overflow-x: hidden;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.75rem;
+  overflow-x: auto;
   white-space: pre-wrap;
   word-break: break-word;
+  border: 1px solid hsl(var(--border-light) / 0.5);
+  box-shadow: 0 1px 2px hsl(var(--shadow));
   width: 100%;
+}
+
+.dark .code-block {
+  background: hsl(var(--bg-tertiary) / 0.4);
+  color: hsl(var(--foreground));
 }
 


### PR DESCRIPTION
## Summary
- polish message bubble visuals with new shadows and rounded corners
- highlight new messages with a short glow animation
- refine code block styles
- toggle dark class in theme provider for `dark:` utilities
- update eslint dev dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885661beed0832a8438cdedf2679fe2