### PR TITLE
Adjust user bubble colors for theme inversion

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", ".vite"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/src/index.css
+++ b/src/index.css
@@ -748,7 +748,7 @@ html:not(.dark) .code-block {
   max-width: 90%;
   border-bottom-right-radius: 0.75rem;
   color: hsl(var(--bg-primary));
-  background: hsl(var(--accent-primary));
+  background: hsl(var(--text-primary));
 }
 
 


### PR DESCRIPTION
## Summary
- ensure ESLint ignores Vite build files
- invert user chat bubble colors so the text uses the theme background and the bubble uses the theme text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688624329934832aa335255c59bd2a48