### PR TITLE
Enable PWA build and update RSS proxy

### DIFF
--- a/src/components/RSSWidget.tsx
+++ b/src/components/RSSWidget.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 import { Loader2, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { fetchArticleText } from '@/services/rssService';
-import { DEFAULT_RSS_FEED } from '@/utils/constants';
+import { DEFAULT_RSS_FEED, CORS_PROXY } from '@/utils/constants';
 
 interface Headline {
   title: string;
@@ -23,7 +23,7 @@ async function fetchRSSSummariesWithLinks(urls: string[]): Promise<Headline[]> {
   
   for (const url of urls) {
     try {
-      const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
+      const resp = await fetch(`${CORS_PROXY}${url}`);
       const data = await resp.text();
       if (!data) continue;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,24 +3,18 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { ThemeProvider } from './hooks/useTheme';
-// import { registerSW } from 'virtual:pwa-register';
+import { registerSW } from 'virtual:pwa-register';
 
-// Register service worker for PWA functionality in production only
-if ('serviceWorker' in navigator && import.meta.env.PROD) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
-      .then((registration) => {
-        console.log('SW registered:', registration);
-      })
-      .catch((error) => {
-        console.warn('Service worker registration failed:', error);
-      });
-  });
-} else if (import.meta.env.DEV) {
-  // Clean up any existing service workers in development
-  navigator.serviceWorker.getRegistrations().then(registrations => {
-    registrations.forEach(registration => registration.unregister());
-  });
+// Register service worker for PWA functionality
+if ('serviceWorker' in navigator) {
+  if (import.meta.env.PROD) {
+    registerSW({ immediate: true });
+  } else {
+    // Clean up any existing service workers in development
+    navigator.serviceWorker.getRegistrations().then(registrations => {
+      registrations.forEach(registration => registration.unregister());
+    });
+  }
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/services/rssService.ts
+++ b/src/services/rssService.ts
@@ -1,6 +1,6 @@
 // Readability gives us a clean article body from messy HTML pages.
 import { Readability } from '@mozilla/readability';
-import { DEFAULT_RSS_FEED } from '@/utils/constants';
+import { DEFAULT_RSS_FEED, CORS_PROXY } from '@/utils/constants';
 
 export interface Headline {
   title: string;
@@ -22,7 +22,7 @@ export async function fetchRSSHeadlines(): Promise<Headline[]> {
 
   for (const url of feeds) {
     try {
-      const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
+      const resp = await fetch(`${CORS_PROXY}${url}`);
       const data = await resp.text();
       if (!data) continue;
 
@@ -54,7 +54,7 @@ export async function fetchRSSHeadlines(): Promise<Headline[]> {
 // Fetch the full article HTML via a CORS proxy and extract just the readable
 // content using Mozilla's Readability algorithm.
 export async function fetchArticleText(url: string): Promise<string> {
-  const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
+  const resp = await fetch(`${CORS_PROXY}${url}`);
   const html = await resp.text();
 
   // Parse the HTML string in a detached document to avoid leaking scripts/styles

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_RSS_FEED = 'https://abcnews.go.com/abcnews/topstories';
+export const CORS_PROXY = 'https://r.jina.ai/';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&    VitePWA({
+    VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['robots.txt', 'icons/*', 'uploads/*'],
       manifest,
@@ -26,7 +26,7 @@ export default defineConfig(({ mode }) => ({
         navigateFallback: 'offline.html'
       }
     }),
-  ].filter(Boolean),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- Always generate PWA service worker and register via `virtual:pwa-register`
- Use Jina CORS proxy for RSS fetching to avoid CORS errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cc764a664832a9d5368c7ca26dd0b