### PR TITLE
fix: correct default RSS feed

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_RSS_FEED = 'https://abcnews.go.com/abcnews/topstories';
+export const DEFAULT_RSS_FEED = 'https://feeds.abcnews.com/abcnews/topstories';
 export const CORS_PROXY = 'https://r.jina.ai/';


### PR DESCRIPTION
## Summary
- point default RSS feed to working ABC News endpoint so RSS headlines display

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d5c9bb530832a9449280c0f01730b