### PR TITLE
Add AI-driven theme generation for light and dark palettes

### DIFF
--- a/src/hooks/useDynamicTheme.ts
+++ b/src/hooks/useDynamicTheme.ts
@@ -1,30 +1,41 @@
-import { useEffect } from 'react';
-import { generateThemePalette } from '@/utils/generateThemePalette';
+import { useEffect, useRef } from 'react';
+import { generateThemePalette, DualThemePalette } from '@/utils/generateThemePalette';
 import { generateNarration } from '@/utils/generateNarration';
+import { toast } from '@/components/ui/sonner';
 
-export function useDynamicTheme(mood: string, enabled: boolean) {
+type ThemeVariant = 'dark' | 'light';
+
+export function useDynamicTheme(mood: string, variant: ThemeVariant, enabled: boolean) {
+  const paletteRef = useRef<DualThemePalette | null>(null);
+
   useEffect(() => {
     const root = document.documentElement;
     if (!enabled) {
       root.removeAttribute('style');
+      paletteRef.current = null;
       return;
     }
 
     let cancelled = false;
     const applyTheme = async () => {
       try {
-        const palette = await generateThemePalette(mood);
-        if (cancelled) return;
+        if (!paletteRef.current) {
+          paletteRef.current = await generateThemePalette(mood);
+          if (cancelled) return;
+          toast.success('AI theme applied');
+          generateNarration(mood);
+        }
+        const palette = paletteRef.current[variant];
         Object.entries(palette).forEach(([key, value]) => {
           root.style.setProperty(key, value);
         });
         root.classList.add('theme-changing');
         setTimeout(() => root.classList.remove('theme-changing'), 500);
-        console.log('Generated AI theme:', palette);
-        generateNarration(mood);
       } catch (e) {
         console.error('Failed to apply AI theme, falling back', e);
         root.removeAttribute('style');
+        paletteRef.current = null;
+        toast.error('Failed to apply AI theme');
       }
     };
 
@@ -32,5 +43,6 @@ export function useDynamicTheme(mood: string, enabled: boolean) {
     return () => {
       cancelled = true;
     };
-  }, [mood, enabled]);
+  }, [mood, variant, enabled]);
 }
+

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -51,7 +51,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     DebouncedStorage.set(STORAGE_KEYS.THEME, { color, variant }, 300);
   }, [color, variant]);
 
-  useDynamicTheme(currentMood, color === 'ai-choice');
+  useDynamicTheme(currentMood, variant, color === 'ai-choice');
 
   const toggleVariant = () => {
     setVariant(variant === 'dark' ? 'light' : 'dark');


### PR DESCRIPTION
## Summary
- Generate AI theme colors for both light and dark variants via LLM
- Apply chosen palette when AI theme is active and confirm with toast
- Ensure dynamic theme hook updates based on current variant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d75548144832aa119f5d09f02ba10