### PR TITLE
Fix AI theme mood regeneration

### DIFF
--- a/src/hooks/useDynamicTheme.ts
+++ b/src/hooks/useDynamicTheme.ts
@@ -7,13 +7,21 @@ type ThemeVariant = 'dark' | 'light';
 
 export function useDynamicTheme(mood: string, variant: ThemeVariant, enabled: boolean) {
   const paletteRef = useRef<DualThemePalette | null>(null);
+  const lastMoodRef = useRef<string | null>(null);
 
   useEffect(() => {
     const root = document.documentElement;
     if (!enabled) {
       root.removeAttribute('style');
       paletteRef.current = null;
+      lastMoodRef.current = null;
       return;
+    }
+
+    // Regenerate the palette when the mood changes
+    if (lastMoodRef.current !== mood) {
+      paletteRef.current = null;
+      lastMoodRef.current = mood;
     }
 
     let cancelled = false;


### PR DESCRIPTION
## Summary
- Regenerate AI-driven theme palette when mood changes
- Reset palette and mood tracking when AI theme disabled

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d7a65c50c832a8ef14de34e850e62