### PR TITLE
fix: load API key from settings fallback

### DIFF
--- a/src/components/ChatBody.tsx
+++ b/src/components/ChatBody.tsx
@@ -15,6 +15,7 @@ import { RSSWidget } from "@/components/RSSWidget";
 import { ChatService, ChatMessage } from "@/services/chatService";
 import { Storage } from "@/utils/storage";
 import { saveWelcomeMessage } from "@/utils/indexedDb";
+import { getPrimaryApiKey } from "@/utils/api";
 
 const getUserName = () => {
   try {
@@ -100,7 +101,7 @@ export const ChatBody = forwardRef<HTMLDivElement, ChatBodyProps>(
         const profiles = JSON.parse(raw) as ProfileBrief[];
         const vivica = profiles.find(p => p.isVivica) || Storage.createVivicaProfile();
 
-        const apiKey = localStorage.getItem('openrouter-api-key');
+        const apiKey = getPrimaryApiKey();
         if (!apiKey) throw new Error('missing api key');
 
         const chatService = new ChatService(apiKey);

--- a/src/hooks/useOpenRouterChat.tsx
+++ b/src/hooks/useOpenRouterChat.tsx
@@ -1,6 +1,7 @@
 
 import { useState, useCallback } from 'react';
 import { ChatService, ChatMessage } from '@/services/chatService';
+import { getPrimaryApiKey } from '@/utils/api';
 
 interface UseOpenRouterChatProps {
   apiKey?: string;
@@ -17,7 +18,8 @@ export const useOpenRouterChat = ({ apiKey }: UseOpenRouterChatProps = {}) => {
     onToken: (token: string) => void,
     onComplete: () => void
   ) => {
-    if (!apiKey) {
+    const key = apiKey || getPrimaryApiKey();
+    if (!key) {
       setError('OpenRouter API key is required');
       return;
     }
@@ -26,7 +28,7 @@ export const useOpenRouterChat = ({ apiKey }: UseOpenRouterChatProps = {}) => {
     setError(null);
 
     try {
-      const chatService = new ChatService(apiKey);
+      const chatService = new ChatService(key);
       const response = await chatService.sendMessage({
         model,
         messages,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,6 +20,7 @@ import {
   ConversationEntry,
 } from "@/utils/indexedDb";
 import { useTheme, ThemeColor, ThemeVariant } from "@/hooks/useTheme";
+import { getPrimaryApiKey } from "@/utils/api";
 
 function weatherCodeToText(code: number): string {
   const map: Record<number, string> = {
@@ -519,7 +520,7 @@ const Index = () => {
 
     setIsTyping(true);
 
-    const apiKey = localStorage.getItem('openrouter-api-key');
+    const apiKey = getPrimaryApiKey();
     if (!apiKey) {
       toast.error('Please set your OpenRouter API key in Settings.');
       setIsTyping(false);
@@ -904,7 +905,7 @@ const Index = () => {
   const handleSaveSummary = async () => {
     if (!currentConversation || !currentProfile) return;
 
-    const apiKey = localStorage.getItem('openrouter-api-key');
+    const apiKey = getPrimaryApiKey();
     if (!apiKey) {
       toast.error('Please set your OpenRouter API key in Settings.');
       return;
@@ -937,7 +938,7 @@ const Index = () => {
     const conversation = conv || currentConversation;
     if (!conversation || !currentProfile) return;
 
-    const apiKey = localStorage.getItem('openrouter-api-key');
+    const apiKey = getPrimaryApiKey();
     if (!apiKey) {
       toast.error('Please set your OpenRouter API key in Settings.');
       return;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,10 @@
+export function getPrimaryApiKey(): string {
+  const direct = localStorage.getItem('openrouter-api-key');
+  if (direct) return direct;
+  try {
+    const settings = JSON.parse(localStorage.getItem('vivica-settings') || '{}');
+    return settings.apiKey1 || settings.apiKey2 || settings.apiKey3 || '';
+  } catch {
+    return '';
+  }
+}

--- a/src/utils/generateThemePalette.ts
+++ b/src/utils/generateThemePalette.ts
@@ -1,5 +1,6 @@
 import { ChatService, ChatMessage } from '@/services/chatService';
 import { STORAGE_KEYS } from '@/utils/storage';
+import { getPrimaryApiKey } from '@/utils/api';
 
 export type ThemePalette = Record<string, string>;
 export type DualThemePalette = {
@@ -65,7 +66,7 @@ export async function generateThemePalette(mood: string): Promise<DualThemePalet
     const profile = profiles.find(p => p.id === profileId);
     if (!profile) throw new Error('No active profile');
 
-    const apiKey = localStorage.getItem('openrouter-api-key');
+    const apiKey = getPrimaryApiKey();
     if (!apiKey) throw new Error('missing api key');
 
     const chatService = new ChatService(apiKey);


### PR DESCRIPTION
## Summary
- add helper to fetch API key from legacy and new settings locations
- update chat, welcome message, theme generation, and OpenRouter hook to use helper

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d978853a0832a9d177265be85c549