### PR TITLE
fix: show rss headlines

### DIFF
--- a/src/components/RSSWidget.tsx
+++ b/src/components/RSSWidget.tsx
@@ -23,7 +23,8 @@ async function fetchRSSSummariesWithLinks(urls: string[]): Promise<Headline[]> {
   
   for (const url of urls) {
     try {
-      const resp = await fetch(`${CORS_PROXY}${url}`);
+      // Use encoded URL with the proxy to bypass CORS restrictions
+      const resp = await fetch(`${CORS_PROXY}${encodeURIComponent(url)}`);
       const data = await resp.text();
       if (!data) continue;
 

--- a/src/services/rssService.ts
+++ b/src/services/rssService.ts
@@ -22,7 +22,8 @@ export async function fetchRSSHeadlines(): Promise<Headline[]> {
 
   for (const url of feeds) {
     try {
-      const resp = await fetch(`${CORS_PROXY}${url}`);
+      // Use proxy with encoded URL to avoid CORS issues
+      const resp = await fetch(`${CORS_PROXY}${encodeURIComponent(url)}`);
       const data = await resp.text();
       if (!data) continue;
 
@@ -54,7 +55,8 @@ export async function fetchRSSHeadlines(): Promise<Headline[]> {
 // Fetch the full article HTML via a CORS proxy and extract just the readable
 // content using Mozilla's Readability algorithm.
 export async function fetchArticleText(url: string): Promise<string> {
-  const resp = await fetch(`${CORS_PROXY}${url}`);
+  // Fetch article content through the proxy and decode it
+  const resp = await fetch(`${CORS_PROXY}${encodeURIComponent(url)}`);
   const html = await resp.text();
 
   // Parse the HTML string in a detached document to avoid leaking scripts/styles

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_RSS_FEED = 'https://feeds.abcnews.com/abcnews/topstories';
-export const CORS_PROXY = 'https://r.jina.ai/';
+// Proxy to bypass CORS restrictions when fetching RSS feeds and articles.
+// Uses allorigins to fetch the remote content server-side.
+export const CORS_PROXY = 'https://api.allorigins.win/raw?url=';


### PR DESCRIPTION
## Summary
- use allorigins proxy and encoded URL fetching for RSS feeds
- ensure article and feed requests pass through the proxy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a56baf20c8832a8f61eb44169220ba