### PR TITLE
Expand backup coverage, validate API keys, and add reset option

### DIFF
--- a/src/utils/memoryUtils.ts
+++ b/src/utils/memoryUtils.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from "@/services/chatService";
+import { ChatMessage, ChatService } from "@/services/chatService";
 import { toast } from "sonner";
 import {
   saveMemoryToDb,
@@ -137,21 +137,14 @@ export async function saveConversationMemory(
   `;
 
   try {
-    // TODO: refactor to use ChatService so we get API key fallback and telemetry
-    const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model,
-        messages: [
-          { role: 'system', content: 'You are Vivica, summarizing conversations concisely.' },
-          { role: 'user', content: prompt }
-        ],
-        temperature: 0.3 // Lower temp for more factual summaries
-      })
+    const chatService = new ChatService(apiKey);
+    const response = await chatService.sendMessage({
+      model,
+      messages: [
+        { role: 'system', content: 'You are Vivica, summarizing conversations concisely.' },
+        { role: 'user', content: prompt }
+      ],
+      temperature: 0.3
     });
 
     const data = await response.json();

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -175,16 +175,27 @@ export const STORAGE_KEYS = {
 
 export async function exportAllData(): Promise<Record<string, unknown>> {
   const data: Record<string, unknown> = {};
-  Object.values(STORAGE_KEYS).forEach(key => {
-    const value = localStorage.getItem(key);
-    if (value) {
-      try {
-        data[key] = JSON.parse(value);
-      } catch {
-        data[key] = value;
+
+  // Export all relevant localStorage keys
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key) continue;
+    // Include all app data keys and API keys
+    if (
+      key.startsWith('vivica-') ||
+      key === 'openrouter-api-key' ||
+      key === 'braveApiKey'
+    ) {
+      const value = localStorage.getItem(key);
+      if (value !== null) {
+        try {
+          data[key] = JSON.parse(value);
+        } catch {
+          data[key] = value;
+        }
       }
     }
-  });
+  }
 
   // Include IndexedDB data
   try {
@@ -211,11 +222,12 @@ export async function exportAllData(): Promise<Record<string, unknown>> {
 }
 
 export async function importAllData(data: Record<string, unknown>): Promise<void> {
-    Object.entries(data).forEach(([key, value]) => {
-      if (Object.values(STORAGE_KEYS).includes(key as string)) {
-        Storage.set(key, value);
-      }
-    });
+  // Restore localStorage data
+  Object.entries(data).forEach(([key, value]) => {
+    if (!key.startsWith('_')) {
+      Storage.set(key, value);
+    }
+  });
 
   // Import IndexedDB data if present
   try {


### PR DESCRIPTION
## Summary
- Export/import now capture all app data, including API keys, settings, profiles, and IndexedDB content
- API key entry verifies keys before saving for immediate feedback
- Summarize & Save uses ChatService and a Reset App button restores default state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a596b6829c832aa5ebf4dc69f9ee62