### PR TITLE
Fix backup restore for memory profile data

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -225,7 +225,12 @@ export async function importAllData(data: Record<string, unknown>): Promise<void
   // Restore localStorage data
   Object.entries(data).forEach(([key, value]) => {
     if (!key.startsWith('_')) {
-      Storage.set(key, value);
+      if (typeof value === 'string') {
+        // Preserve raw strings without double JSON encoding
+        localStorage.setItem(key, value);
+      } else {
+        Storage.set(key, value);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- avoid double-stringifying values when restoring backups
- preserve raw string storage to keep memory profile data connected

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59d174cc0832a86be8b368f13341f