### PR TITLE
feat: add mardi gras theme

### DIFF
--- a/src/components/ProfilesModal.tsx
+++ b/src/components/ProfilesModal.tsx
@@ -64,6 +64,7 @@ export const ProfilesModal = ({ isOpen, onClose }: ProfilesModalProps) => {
     { value: 'red', label: 'Red', color: '#ef4444' },
     { value: 'green', label: 'Green', color: '#10b981' },
     { value: 'purple', label: 'Purple', color: '#8b5cf6' },
+    { value: 'mardi-gras', label: 'Mardi Gras', color: '#6366f1' },
     { value: 'ai-choice', label: 'AI Choice', color: '#ffffff' },
   ];
 

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -29,6 +29,7 @@ export const ThemeSelector = () => {
     { value: 'green', label: 'Green', color: '#10b981' },
     { value: 'purple', label: 'Purple', color: '#8b5cf6' },
     { value: 'mardi-gold', label: 'Mardi Gold', color: '#d4bd8c' },
+    { value: 'mardi-gras', label: 'Mardi Gras', color: '#6366f1' },
     { value: 'ai-choice', label: 'AI Choice', color: '#ffffff' },
   ];
 

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -16,6 +16,7 @@ export type ThemeColor =
   | 'green'
   | 'purple'
   | 'mardi-gold'
+  | 'mardi-gras'
   | 'ai-choice';
 
 // Add a toggleVariant function for compatibility

--- a/src/index.css
+++ b/src/index.css
@@ -293,6 +293,172 @@
   --amber-500: 41 46% 38%;
 }
 
+/* ──────────────────  | MARDI GRAS THEMES ────────────────── */
+/* Palette (hex → hsl)
+   Purple  #6366f1 → 239 84% 67%
+   Gold    #f59e0b →  36 91% 50%
+   Green   #10b981 → 160 84% 39%
+   Cream   #fef9c3 →  54 97% 88%
+   Ink     #0a0a0a →   0  0%  4%
+*/
+
+/* MARDI GRAS — DARK (club stage) */
+[data-theme="mardi-gras-dark"] {
+  /* Core */
+  --background: 0 0% 4%;           /* Ink */
+  --foreground: 54 97% 88%;        /* Cream */
+
+  --primary: 239 84% 67%;          /* Purple */
+  --primary-foreground: 0 0% 0%;
+
+  --accent: 36 91% 50%;            /* Gold */
+  --accent-foreground: 0 0% 0%;
+
+  --ring: 36 91% 50%;              /* focus ring = gold */
+
+  /* Surfaces */
+  --card: 0 0% 7%;
+  --card-foreground: 54 97% 88%;
+  --popover: 0 0% 7%;
+  --popover-foreground: 54 97% 88%;
+  --muted: 0 0% 12%;
+  --muted-foreground: 0 0% 70%;
+  --secondary: 0 0% 10%;
+  --secondary-foreground: 54 97% 88%;
+
+  /* Borders / inputs */
+  --border: 0 0% 20%;
+  --input: 0 0% 14%;
+
+  /* Sidebar */
+  --sidebar-background: 0 0% 3%;
+  --sidebar-foreground: 54 97% 88%;
+  --sidebar-primary: 36 91% 50%;
+  --sidebar-primary-foreground: 0 0% 0%;
+  --sidebar-accent: 0 0% 10%;
+  --sidebar-accent-foreground: 54 97% 88%;
+  --sidebar-border: 0 0% 18%;
+  --sidebar-ring: 36 91% 50%;
+
+  /* Your custom tokens */
+  --bg-primary: 0 0% 4%;
+  --bg-secondary: 0 0% 7%;
+  --bg-tertiary: 0 0% 10%;
+  --bg-hover: 0 0% 13%;
+  --bg-active: 0 0% 16%;
+
+  --text-primary: 54 97% 88%;      /* cream text */
+  --text-secondary: 0 0% 80%;
+  --text-muted: 0 0% 60%;
+
+  --accent-primary: 36 91% 50%;    /* gold */
+  --accent-secondary: 160 84% 39%; /* green */
+  --border-custom: 0 0% 20%;
+  --border-light: 0 0% 16%;
+
+  --success: 160 84% 39%;          /* green */
+  --warning: 36 91% 50%;           /* gold */
+  --danger: 0 100% 50%;
+  --info: 239 84% 67%;             /* purple as info */
+
+  --theme-primary: 239 84% 67%;    /* ramp for gradients */
+  --theme-accent: 36 91% 50%;
+
+  --bubble: 0 0% 0%;
+  --assistant-bubble-border: 1px solid hsl(var(--border-custom));
+
+  /* Brand neon + gradients */
+  --gradient-primary: linear-gradient(135deg,
+      hsl(239 84% 67%) 0%,
+      hsl(36 91% 50%) 55%,
+      hsl(160 84% 39%) 100%);
+  --gradient-accent: linear-gradient(135deg,
+      hsl(var(--bg-primary)) 0%,
+      hsl(var(--bg-hover)) 100%);
+  --shadow: 0 0% 100% / 0.12;
+  --shadow-heavy: 0 0% 100% / 0.24;
+}
+
+/* MARDI GRAS — LIGHT (parade day) */
+[data-theme="mardi-gras-light"] {
+  /* Core */
+  --background: 0 0% 100%;
+  --foreground: 0 0% 10%;
+
+  --primary: 239 84% 55%;          /* slightly darker purple for contrast */
+  --primary-foreground: 0 0% 100%;
+
+  --accent: 36 91% 45%;            /* gold */
+  --accent-foreground: 0 0% 100%;
+
+  --ring: 36 91% 45%;
+
+  /* Surfaces */
+  --card: 0 0% 96%;
+  --card-foreground: 0 0% 10%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 10%;
+  --muted: 0 0% 90%;
+  --muted-foreground: 0 0% 35%;
+  --secondary: 0 0% 88%;
+  --secondary-foreground: 0 0% 10%;
+
+  /* Borders / inputs */
+  --border: 0 0% 80%;
+  --input: 0 0% 90%;
+
+  /* Sidebar */
+  --sidebar-background: 0 0% 96%;
+  --sidebar-foreground: 0 0% 10%;
+  --sidebar-primary: 239 84% 55%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent: 0 0% 88%;
+  --sidebar-accent-foreground: 0 0% 10%;
+  --sidebar-border: 0 0% 82%;
+  --sidebar-ring: 36 91% 45%;
+
+  /* Your custom tokens */
+  --bg-primary: 0 0% 100%;
+  --bg-secondary: 0 0% 96%;
+  --bg-tertiary: 0 0% 90%;
+  --bg-hover: 0 0% 88%;
+  --bg-active: 0 0% 84%;
+
+  --text-primary: 0 0% 10%;
+  --text-secondary: 0 0% 28%;
+  --text-muted: 0 0% 42%;
+
+  --accent-primary: 36 91% 45%;    /* gold */
+  --accent-secondary: 160 84% 39%; /* green */
+  --border-custom: 0 0% 80%;
+  --border-light: 0 0% 85%;
+
+  --success: 160 84% 32%;
+  --warning: 36 91% 45%;
+  --danger: 0 100% 45%;
+  --info: 239 84% 55%;
+
+  --theme-primary: 239 84% 55%;
+  --theme-accent: 36 91% 50%;
+
+  --bubble: 0 0% 100%;
+
+  --gradient-primary: linear-gradient(135deg,
+      hsl(239 84% 55%) 0%,
+      hsl(36 91% 50%) 55%,
+      hsl(160 84% 39%) 100%);
+  --gradient-accent: linear-gradient(135deg,
+      hsl(var(--bg-primary)) 0%,
+      hsl(var(--bg-hover)) 100%);
+  --shadow: 0 0% 0% / 0.10;
+  --shadow-heavy: 0 0% 0% / 0.22;
+}
+
+/* Optional helpers */
+.brand-gradient { background-image: var(--gradient-primary); }
+.glow-focus:focus-visible { outline: none; box-shadow: 0 0 0 3px hsl(var(--ring) / 0.35); }
+.neon-border { box-shadow: 0 0 24px hsl(var(--accent) / 0.35), inset 0 0 0 1px hsl(var(--accent) / 0.4); }
+
 /* DEFAULT LIGHT THEME - White */
 [data-theme="default-light"] {
   --bg-primary: 0 0% 100%;


### PR DESCRIPTION
## Summary
- add Mardi Gras dark and light theme palettes
- allow selecting Mardi Gras in theme controls
- support Mardi Gras in theme type

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5d02f9708832ab702a90238144242