### PR TITLE
feat: add model capability and request telemetry

### DIFF
--- a/src/services/modelCaps.ts
+++ b/src/services/modelCaps.ts
@@ -1,0 +1,39 @@
+export const MODEL_CAPS: Record<string, { supports: Partial<Record<
+  'frequency_penalty' | 'presence_penalty' | 'top_p' | 'max_output_tokens' | 'tools' | 'json_mode' | 'stream', boolean>>,
+  maxInputTokens?: number,
+}> = {
+  'gpt-4o-mini': {
+    supports: {
+      frequency_penalty: true,
+      presence_penalty: true,
+      top_p: true,
+      tools: true,
+      json_mode: true,
+      stream: true,
+    },
+    maxInputTokens: 128_000,
+  },
+  'qwen-small': {
+    supports: {
+      frequency_penalty: false,
+      presence_penalty: false,
+      top_p: true,
+      tools: false,
+      json_mode: false,
+      stream: true,
+    },
+    maxInputTokens: 32_768,
+  },
+};
+
+export function sanitizeParams(model: string, opts: Record<string, unknown>) {
+  const caps = MODEL_CAPS[model]?.supports || {};
+  const o: Record<string, unknown> = { ...opts };
+  if (caps.frequency_penalty === false) delete (o as { frequency_penalty?: unknown }).frequency_penalty;
+  if (caps.presence_penalty === false) delete (o as { presence_penalty?: unknown }).presence_penalty;
+  if (caps.tools === false) delete (o as { tools?: unknown }).tools;
+  if (caps.json_mode === false) delete (o as { response_format?: unknown }).response_format;
+  if (caps.top_p === false) delete (o as { top_p?: unknown }).top_p;
+  if (caps.stream === false) (o as { stream?: unknown }).stream = false;
+  return o;
+}

--- a/src/services/tokenUtils.ts
+++ b/src/services/tokenUtils.ts
@@ -1,0 +1,18 @@
+import type { ChatMessage } from './chatService';
+
+export function estimateTokens(text: string): number {
+  return Math.ceil((text || '').length / 4);
+}
+
+export function enforceBudget(messages: ChatMessage[], limit = 4000) {
+  const headroom = Math.floor(limit * 0.8);
+  const estimate = () => messages.reduce((s, m) => s + estimateTokens(m.content), 0);
+  while (messages.length && estimate() > headroom) {
+    messages.shift();
+  }
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'user' || last.content.trim().replace(/\p{C}+/gu, '') === '') {
+    throw new Error('EMPTY_USER_MESSAGE');
+  }
+  return messages;
+}


### PR DESCRIPTION
## Summary
- add per-model capability map and sanitize outgoing parameters
- enforce token budgets and block empty user messages
- instrument chat requests with request IDs, retries, and circuit breaker logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae935b6170832aaae9c3d8c6d076ea