### PR TITLE
Improve chat request robustness

### DIFF
--- a/server/__tests__/sendChat.test.ts
+++ b/server/__tests__/sendChat.test.ts
@@ -14,3 +14,25 @@ test('sendChat times out', async () => {
   await assert.rejects(() => sendChat({ model: 'x', messages: [] }, { timeoutMs: 10 }), /TIMEOUT/);
   global.fetch = orig as typeof fetch;
 });
+
+test('sendChat retries on server error', async () => {
+  let calls = 0;
+  const orig = global.fetch;
+  global.fetch = async () => {
+    calls++;
+    if (calls === 1) {
+      return new Response(JSON.stringify({ error: { message: 'fail' } }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  };
+  const res = await sendChat({ model: 'x', messages: [{ role: 'user', content: 'hi' }] }, { retries: 1 });
+  assert.equal(calls, 2);
+  assert.deepEqual(res, { ok: true });
+  global.fetch = orig as typeof fetch;
+});

--- a/server/lib/llmClient.ts
+++ b/server/lib/llmClient.ts
@@ -3,7 +3,7 @@ const CACHE_TTL = 60_000;
 
 export async function callLLM({
   messages, model, signal, maxTokens = 512,
-  retry = 1, requestId
+  retry = 2, requestId
 }: {
   messages: Array<{role:string; content:string}>;
   model: string;
@@ -35,7 +35,7 @@ export async function callLLM({
 
       if (res.status === 429 || res.status >= 500) {
         if (attempt < retry) {
-          const backoff = Math.min(2000 * (attempt + 1) + Math.random() * 400, 6000);
+          const backoff = Math.min(500 * 2 ** attempt + Math.random() * 500, 4000);
           await new Promise(r => setTimeout(r, backoff));
           continue;
         }
@@ -49,6 +49,8 @@ export async function callLLM({
       return json;
     } catch (e) {
       if (attempt >= retry) throw e;
+      const backoff = Math.min(500 * 2 ** attempt + Math.random() * 500, 4000);
+      await new Promise(r => setTimeout(r, backoff));
     }
   }
 }

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -5,23 +5,52 @@ export interface ChatPayload {
   max_tokens?: number;
 }
 
-export async function sendChat(payload: ChatPayload, { timeoutMs = 30000 } = {}) {
-  const controller = new AbortController();
-  const to = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
-    });
-    if (!res.ok) throw new Error(`CHAT_${res.status}`);
-    return await res.json();
-  } catch (e: unknown) {
-    const err = e as { name?: string };
-    if (err.name === 'AbortError') throw new Error('TIMEOUT');
-    throw e;
-  } finally {
-    clearTimeout(to);
+export async function sendChat(
+  payload: ChatPayload,
+  { timeoutMs = 30000, retries = 2 }: { timeoutMs?: number; retries?: number } = {}
+) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const to = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        let message = `CHAT_${res.status}`;
+        try {
+          const data = await res.json();
+          message = data?.error?.message || message;
+        } catch {}
+
+        if ((res.status === 429 || res.status >= 500) && attempt < retries) {
+          const backoff = Math.min(500 * 2 ** attempt, 4000);
+          await new Promise(r => setTimeout(r, backoff));
+          continue;
+        }
+        const err = new Error(message) as Error & { status?: number };
+        err.status = res.status;
+        throw err;
+      }
+
+      return await res.json();
+    } catch (e: unknown) {
+      const err = e as { name?: string };
+      if (err.name === 'AbortError') {
+        if (attempt >= retries) throw new Error('TIMEOUT');
+      } else {
+        if (attempt >= retries) throw e;
+      }
+      const backoff = Math.min(500 * 2 ** attempt, 4000);
+      await new Promise(r => setTimeout(r, backoff));
+    } finally {
+      clearTimeout(to);
+    }
   }
+
+  throw new Error('CHAT_FAILED');
 }


### PR DESCRIPTION
## Summary
- Retry `/api/chat` requests with exponential backoff and better error reporting
- Harden LLM client with network retry logic and jittered backoff
- Add tests covering new retry behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8939ec9b4832a90f2cbdc0cd647b8